### PR TITLE
ci: build dashboard before installing the package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Build dashboard
+        working-directory: src/clickmem/dashboard
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -31,7 +48,7 @@ jobs:
           echo "Releasing version ${VERSION}"
           sed -i "s/^version = .*/version = \"${VERSION}\"/" pyproject.toml
 
-      - name: Build wheel + sdist (includes prebuilt dashboard/dist)
+      - name: Build wheel + sdist (dashboard/dist is prebuilt above)
         run: python -m build
 
       - name: Publish to PyPI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Build dashboard
+        working-directory: src/clickmem/dashboard
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary

CI has been red on every run of the `test` workflow on `main` since the v1 rebuild (32d091e), and the `release v0-final` run failed the same way — which is why v1 hasn't shipped to PyPI.

Root cause: `pyproject.toml` force-includes `src/clickmem/dashboard/dist/` into the wheel, but that directory is gitignored (it's a Vite build artefact regenerated by `make dashboard`). Neither `test.yml` nor `release.yml` builds the dashboard before invoking the Python build backend, so hatchling fails with:

```
FileNotFoundError: Forced include not found:
.../src/clickmem/dashboard/dist
```

Example failing run: https://github.com/auxten/clickmem/actions/runs/25904341501

## Fix

Add Node 20 + pnpm 9 setup, then `pnpm install --frozen-lockfile && pnpm build` in `src/clickmem/dashboard`, before the Python install / build step. Applied to both `test.yml` and `release.yml`. This matches:

- the `make dashboard` target's `pnpm install && pnpm build` recipe, and
- the pnpm version already pinned in `dashboard.yml` (`version: 9`).

The misleading comment "(includes prebuilt dashboard/dist)" on the release wheel build step is updated to point to the now-actually-prebuilt step above it.

## Trade-offs considered

- **Inline build per matrix job** (chosen): simple, low surface area. Each Python matrix job (2 OS × 3 versions = 6 jobs) does its own pnpm install + build. Adds ~1 min per job.
- **Separate "build-dashboard" job + artifact**: more efficient, but more workflow surface area and a cross-job dependency. Can be done as a follow-up if CI time becomes a concern.
- **Make the `force-include` conditional** (custom hatch build hook): possible, but skipping the dashboard in editable installs means the running server has no UI at `/dashboard/`, which is a worse default than just building it.

## Test plan

- [ ] CI on this PR turns green on all 6 matrix jobs.
- [ ] After merge, tag a `v1.0.x` to verify the `release` workflow runs end-to-end and publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)